### PR TITLE
Make request param optional

### DIFF
--- a/DCO.txt
+++ b/DCO.txt
@@ -28,6 +28,6 @@ Developer's Certificate of Origin 1.1
 And please confirm your certification to the above by adding the following
 line to your patch:
 
-	Signed-off-by: John Doe <john.doe@example.org>
+	Signed-off-by: Vincent Pham <vipham@us.ibm.com>
 
 using your real name (sorry, no pseudonyms or anonymous contributions).

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -25,6 +25,9 @@ var ARGS_REGEX = /\{([0-9]+)\}/g,
 // in-memory bundle hierarchy (filename -> lang -> country -> bundle)
 var _bundles = {};
 
+// current locale to be used if the request object is not given in the exported get function
+var _currentLocale = null;
+
 /**
  * Registers an extension with node.js to allow requiring properties files directly.
  * e.g.
@@ -37,6 +40,20 @@ require.extensions['.properties'] = function(module, filename) {
     // write a module that exports the i18n message bundle
     var i18nPath = path.join(__dirname, 'i18n');
     return module._compile('module.exports = require(' + JSON.stringify(i18nPath) + ')._loadBundle(' + JSON.stringify(filename) + ');', filename);
+};
+
+/**
+ * Sets the current locale
+ */
+exports.setLocale = function (reqOrLocale) {
+	_currentLocale = resolveLocale(reqOrLocale);
+};
+
+/**
+ * Returns the current locale
+ */ 
+exports.getLocale = function () {
+	return _currentLocale;
 };
 
 /**
@@ -299,9 +316,9 @@ function get(path, key, arg2, arg3) {
         args;
     if (Array.isArray(arg2)) {
         args = arg2;
-        localeOrReq = arg3;
+        localeOrReq = arg3 ? arg3 : _currentLocale;
     } else {
-        localeOrReq = arg2;
+        localeOrReq = arg2 ? arg2 : _currentLocale;
     }
     // validate args
     if (typeof(key) !== 'string') {

--- a/lib/i18n.js
+++ b/lib/i18n.js
@@ -316,9 +316,9 @@ function get(path, key, arg2, arg3) {
         args;
     if (Array.isArray(arg2)) {
         args = arg2;
-        localeOrReq = arg3 ? arg3 : _currentLocale;
+        localeOrReq = (arg3 || !_currentLocale) ? arg3 : _currentLocale;
     } else {
-        localeOrReq = arg2 ? arg2 : _currentLocale;
+        localeOrReq = (arg2 || !_currentLocale) ? arg2 : _currentLocale;
     }
     // validate args
     if (typeof(key) !== 'string') {


### PR DESCRIPTION
Added new enhancement to allow setting a locale at initialization so that later calls to the get function can avoid passing in a request or locale object.